### PR TITLE
import plotly.graph_objects

### DIFF
--- a/gunc/visualisation.py
+++ b/gunc/visualisation.py
@@ -1,5 +1,5 @@
 import sys
-import plotly
+import plotly.graph_objects
 import pandas as pd
 from ._version import get_versions
 from .get_scores import chim_score


### PR DESCRIPTION
plotly.graph_objects is auto-generated and should be imported by `import plotly.graph_objects as go`

before:
```cmd
]$gunc plot --diamond_file gunc_out/diamond_output/concoct_11_sub.diamond.out
[START] 22:56:22 2021-01-22
[INFO] Subsampling data to display 1000 contigs.
Traceback (most recent call last):
  File "~/software/anaconda3/envs/python36/bin/gunc", line 10, in <module>
    sys.exit(main())
  File "~/software/anaconda3/envs/python36/lib/python3.6/site-packages/gunc/gunc.py", line 527, in main
    plot(args)
  File "~/software/anaconda3/envs/python36/lib/python3.6/site-packages/gunc/gunc.py", line 502, in plot
    args.remove_minor_clade_level)
  File "~/software/anaconda3/envs/python36/lib/python3.6/site-packages/gunc/visualisation.py", line 286, in create_viz_from_diamond_file
    viz_data = prepare_plot_data(node_data, link_data)
  File "~/software/anaconda3/envs/python36/lib/python3.6/site-packages/gunc/visualisation.py", line 203, in prepare_plot_data
    return plotly.graph_objects.Figure(plot_data)
AttributeError: module 'plotly' has no attribute 'graph_objects'
```
after:
```cmd
]$gunc plot --diamond_file gunc_out/diamond_output/concoct_11_sub.diamond.out
[START] 22:56:34 2021-01-22
[INFO] Subsampling data to display 1000 contigs.
[INFO]  22:56:41 Runtime: 0:00:07
[END]   22:56:41 2021-01-22
```