### PR TITLE
Update database selection option in documentation

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -111,7 +111,7 @@ Required Flags
 Optional Flags
 ^^^^^^^^^^^^^^
 
- * :code:`--db` Which db to download (progenomes or gtdb). Default: progenomes
+ * :code:`-db` Which db to download (progenomes or gtdb). Default: progenomes
 
 ------------
 


### PR DESCRIPTION
The documentation for download_db has an extra "-" in the database selection option