### PR TITLE
Use .items instead of .iteritems to suppress deprecation warning from pandas v1.5.0 or newer

### DIFF
--- a/gunc/get_scores.py
+++ b/gunc/get_scores.py
@@ -111,7 +111,7 @@ def calc_expected_conditional_entropy(contigs, taxons):
     taxon_probability = taxon_probability.values
 
     total_entropy = 0.0
-    for bucket_size, contig_count in contribution.iteritems():
+    for bucket_size, contig_count in contribution.items():
         if bucket_size <= MAX_BUCKET_SIZE:
             total_entropy += contig_count * expected_entropy_estimate(
                 taxon_probability, bucket_size


### PR DESCRIPTION
Running gunc v1.0.5 with pandas v1.5.0 or newer produces the error:
```
get_scores.py:114: FutureWarning: iteritems is deprecated and will be removed in a future version. Use .items instead.
```

This is because .iteritems was deprecated in pandas v1.5.0 to mirror python3's dictionary api deprecating the same function (see the [release notes](https://pandas.pydata.org/docs/whatsnew/v1.5.0.html) or the [discussion about the deprecation](https://github.com/pandas-dev/pandas/pull/45321)).

This pull request fixes the warning by replacing the usage of .iteritems with .items. The change is also compatible with older versions of pandas since [.iteritems calls .items internally](https://github.com/pandas-dev/pandas/blob/v1.0.0/pandas/core/series.py#L1508), meaning there is no difference between the two.

Thanks for creating gunc!